### PR TITLE
Disable ValueError from Missing Vocab File

### DIFF
--- a/t5chem/run_trainer.py
+++ b/t5chem/run_trainer.py
@@ -143,9 +143,9 @@ def train(args):
         if not os.path.isfile(vocab_path):
             vocab_path = args.vocab
             if not vocab_path:
-                raise ValueError(
-                        "Can't find a vocabulary file at path '{}'.".format(args.pretrain)
-                    )
+                vocab_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'vocab/'+tokenizer_type+'.txt')
+                logging.warning("No vocabulary file found at path '{}'. \
+                                Using default one at '{}'".format(args.pretrain, vocab_path))
         tokenizer = tokenizer_map[tokenizer_type](vocab_file=vocab_path)
         model.config.tokenizer = tokenizer_type # type: ignore
         model.config.task_type = args.task_type # type: ignore


### PR DESCRIPTION
## Problem
When running `t5chem train` with a HuggingFace pretrained model (e.g., `google-t5/t5-small`), users encountered a "Can't find a vocabulary file at path vocab/" error because the command expected a local vocabulary directory that isn't included with HuggingFace models.

## Solution
Updated the code to handle HuggingFace T5 models directly without requiring a manual `vocab/` directory.

## Outcome
Users can now use the `--pretrain` flag with HuggingFace model references without additional setup steps. For example, 
```
t5chem train --data_dir MLM/train_0 --output_dir model/pretrain/v1_1-small --task_type pretrain --num_epoch 1 --pretrain google/t5-v1_1-small
```